### PR TITLE
Potential fix for code scanning alert no. 7: Incorrect conversion between integer types

### DIFF
--- a/parsers/engine/parser/parser-v3.go
+++ b/parsers/engine/parser/parser-v3.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+	"math"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -384,6 +385,10 @@ func (p *parserv3) decodeBinaryPayload(bufferTail types.BufferInterface) ([]*pac
 		packetLen, err := strconv.ParseInt(string(lenByte), 10, 64)
 		if err != nil {
 			return packets, err
+		}
+		// Ensure packetLen can be safely converted to int and is non-negative.
+		if packetLen < 0 || packetLen > int64(math.MaxInt) {
+			return packets, ErrInvalidDataLength
 		}
 
 		if isString {


### PR DESCRIPTION
Potential fix for [https://github.com/zishang520/socket.io/security/code-scanning/7](https://github.com/zishang520/socket.io/security/code-scanning/7)

To fix the problem, we must ensure that we never convert `packetLen` to a smaller integer type without checking that the value is within bounds. There are two sensible options: (1) parse with a bit size that matches the target type (`strconv.ParseInt(..., 10, 32)` and keep `packetLen` as `int32`), or (2) keep parsing as 64‑bit and add explicit lower/upper bound checks before any conversion to `int`. Given the existing code uses `int64` for the loop counter `k` and treats `packetLen` conceptually as a count of UTF‑16 code units, the least intrusive, behavior‑preserving fix is to keep `packetLen` as `int64` but guard the `int(packetLen)` cast with appropriate bounds checks.

Concretely, in `parsers/engine/parser/parser-v3.go`, after parsing `packetLen` at line 384, we should add a validation step: ensure `packetLen` is non‑negative and does not exceed `math.MaxInt` (the maximum value of type `int` on the running platform). If the value is out of range, we should treat it as an error and return, similar to other error paths in this function (e.g., invalid length, I/O errors). We will need to import the standard `math` package at the top of the file to access `math.MaxInt`. Then, at line 424 we can safely call `bufferTail.Next(int(packetLen))`, knowing the cast is well‑defined. This preserves existing behavior for all previously valid values, only rejecting inputs that would previously have led to silent truncation or misbehavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
