### PR TITLE
Potential fix for code scanning alert no. 10: Size computation for allocation may overflow

### DIFF
--- a/pkg/types/buffer.go
+++ b/pkg/types/buffer.go
@@ -266,11 +266,13 @@ func growSlice(b []byte, n int) []byte {
 	//
 	// Instead use the append-make pattern with a nil slice to ensure that
 	// we allocate buffers rounded up to the closest size class.
-	c := len(b) + n // ensure enough space for n elements
 	if n < 0 || len(b) > maxInt-n {
 		panic(ErrTooLarge)
 	}
-	c = max(c, 2*cap(b))
+	c := len(b) + n // ensure enough space for n elements
+	if d := cap(b); d <= maxInt/2 {
+		c = max(c, 2*d)
+	}
 	b2 := append([]byte(nil), make([]byte, c)...)
 	i := copy(b2, b)
 	return b2[:i]


### PR DESCRIPTION
Potential fix for [https://github.com/zishang520/socket.io/security/code-scanning/10](https://github.com/zishang520/socket.io/security/code-scanning/10)

General fix approach: **validate arithmetic bounds before performing size computation used for allocation**. For `len(b)+n`, ensure `n >= 0` and `len(b) <= maxInt-n` first, then compute `c`.

Best minimal fix (no functional behavior change): in `pkg/types/buffer.go`, inside `growSlice`, move the overflow/negative guard above `c := len(b) + n`. This preserves existing panic behavior (`ErrTooLarge`) while removing the overflow operation itself. No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
