### PR TITLE
Potential fix for code scanning alert no. 8: Size computation for allocation may overflow

### DIFF
--- a/pkg/types/buffer.go
+++ b/pkg/types/buffer.go
@@ -270,7 +270,14 @@ func growSlice(b []byte, n int) []byte {
 		panic(ErrTooLarge)
 	}
 	c := len(b) + n // ensure enough space for n elements
-	c = max(c, 2*cap(b))
+
+	// Prefer doubling capacity when possible, but guard against overflow.
+	if capB := cap(b); capB <= maxInt/2 {
+		if doubled := 2 * capB; doubled > c {
+			c = doubled
+		}
+	}
+
 	b2 := append([]byte(nil), make([]byte, c)...)
 	i := copy(b2, b)
 	return b2[:i]


### PR DESCRIPTION
Potential fix for [https://github.com/zishang520/socket.io/security/code-scanning/8](https://github.com/zishang520/socket.io/security/code-scanning/8)

The best fix is to add an explicit overflow guard around the capacity-doubling computation in `growSlice` and only compute doubled capacity when safe.

In `pkg/types/buffer.go`, inside `growSlice` (around lines 269–274 in your snippet), keep the existing `len(b)+n` guard, then replace:

- `c = max(c, 2*cap(b))`

with logic that:
1. Computes `capB := cap(b)`,
2. Checks `capB <= maxInt/2` before doubling,
3. Uses doubled capacity only when it is safe and larger than `c`,
4. Otherwise keeps `c` as `len(b)+n`.

This preserves current behavior (prefer growth to at least 2x capacity) without changing functionality for valid ranges, and prevents overflow in allocation size computation.

No new imports, helper methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
