### PR TITLE
Potential fix for code scanning alert no. 12: Size computation for allocation may overflow

### DIFF
--- a/pkg/types/buffer.go
+++ b/pkg/types/buffer.go
@@ -270,6 +270,9 @@ func growSlice(b []byte, n int) []byte {
 		panic(ErrTooLarge)
 	}
 	c := len(b) + n // ensure enough space for n elements
+	if c < 0 || c < len(b) {
+		panic(ErrTooLarge)
+	}
 
 	// Prefer doubling capacity when possible, but guard against overflow.
 	if capB := cap(b); capB <= maxInt/2 {


### PR DESCRIPTION
Potential fix for [https://github.com/zishang520/socket.io/security/code-scanning/12](https://github.com/zishang520/socket.io/security/code-scanning/12)

General fix: add an explicit overflow/validity guard immediately after computing allocation size and before any allocation, even if earlier guards exist. This creates a local, obvious safety invariant for static analyzers and future maintainers.

Best concrete fix (single-file, minimal behavior change): in `pkg/types/buffer.go`, inside `growSlice`, keep existing guard and add a second defensive check after `c := len(b) + n` to ensure `c` is not negative and not smaller than `len(b)`. This directly protects the allocation sink (`make([]byte, c)`) and resolves both variants that flow from large JSON payloads.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
