### PR TITLE
perf(broadcast): build PreparedMessage once per broadcast, not per re…

### DIFF
--- a/parsers/engine/packet/packet-type.go
+++ b/parsers/engine/packet/packet-type.go
@@ -3,6 +3,7 @@ package packet
 
 import (
 	"io"
+	"sync"
 
 	"github.com/zishang520/socket.io/v3/pkg/types"
 )
@@ -31,6 +32,12 @@ type Options struct {
 	Compress *bool `json:"compress,omitempty" msgpack:"compress,omitempty"`
 	// WsPreEncodedFrame contains a pre-encoded WebSocket frame.
 	WsPreEncodedFrame types.BufferInterface `json:"wsPreEncodedFrame,omitempty" msgpack:"wsPreEncodedFrame,omitempty"`
+	// PreparedFrame, when non-nil, is shared across all recipients of a
+	// broadcast and lets transports build their per-broadcast prepared
+	// frame (e.g. ws.NewPreparedMessage) once instead of once per
+	// recipient. The same cache may be used by multiple transport
+	// types; entries are keyed by transport name.
+	PreparedFrame *PreparedFrame `json:"-" msgpack:"-"`
 }
 
 // NewOptions creates a new Options with the given compress flag.
@@ -63,6 +70,44 @@ func NewWithOptions(packetType Type, data io.Reader, options *Options) *Packet {
 		Data:    data,
 		Options: options,
 	}
+}
+
+// PreparedFrame is a transport-keyed, build-once cache that lets a
+// broadcast amortize the cost of preparing its WebSocket frame across
+// every recipient. Allocate one instance per broadcast and pass it via
+// Options.PreparedFrame; the zero value is ready to use and safe for
+// concurrent use.
+type PreparedFrame struct {
+	mu      sync.Mutex
+	entries map[string]*preparedEntry
+}
+
+type preparedEntry struct {
+	once sync.Once
+	val  any
+	err  error
+}
+
+// Do returns the cached value for key, invoking build at most once per
+// key even when called concurrently. If p is nil, build is invoked on
+// every call (no caching).
+func (p *PreparedFrame) Do(key string, build func() (any, error)) (any, error) {
+	if p == nil {
+		return build()
+	}
+	p.mu.Lock()
+	if p.entries == nil {
+		p.entries = make(map[string]*preparedEntry)
+	}
+	e, ok := p.entries[key]
+	if !ok {
+		e = &preparedEntry{}
+		p.entries[key] = e
+	}
+	p.mu.Unlock()
+
+	e.once.Do(func() { e.val, e.err = build() })
+	return e.val, e.err
 }
 
 // Packet types for Engine.IO protocol.

--- a/pkg/types/buffer-ext.go
+++ b/pkg/types/buffer-ext.go
@@ -58,6 +58,26 @@ func (b *Buffer) Clone() *Buffer {
 	return clone
 }
 
+// View returns a Buffer that shares the underlying byte slice with b
+// but has independent read state (off / lastRead). It is intended for
+// hot paths like broadcast send, where the same encoded payload is
+// consumed by many recipients concurrently.
+//
+// Callers MUST treat the returned view (and b itself, while any view
+// is in flight) as read-only with respect to the underlying bytes —
+// any write/grow/truncate on either side will race. Reads through
+// independent views are safe because each view has its own off.
+func (b *Buffer) View() *Buffer {
+	if b == nil {
+		return nil
+	}
+	return &Buffer{
+		buf:      b.buf,
+		off:      b.off,
+		lastRead: b.lastRead,
+	}
+}
+
 // Size returns the original length of the underlying byte slice.
 // Size is the number of bytes available for reading via ReadAt.
 // The returned value is always the same and is not affected by calls
@@ -102,6 +122,15 @@ func (b *BytesBuffer) Clone() BufferInterface {
 	return &BytesBuffer{b.Buffer.Clone()}
 }
 
+// View returns a BytesBuffer that shares b's underlying bytes; see
+// (*Buffer).View for the read-only contract.
+func (b *BytesBuffer) View() BufferInterface {
+	if b == nil || b.Buffer == nil {
+		return nil
+	}
+	return &BytesBuffer{b.Buffer.View()}
+}
+
 func (b *BytesBuffer) GoString() string {
 	if b == nil || b.Buffer == nil {
 		// Special case, useful in debugging.
@@ -134,6 +163,15 @@ func (sb *StringBuffer) Clone() BufferInterface {
 		return nil
 	}
 	return &StringBuffer{sb.Buffer.Clone()}
+}
+
+// View returns a StringBuffer that shares sb's underlying bytes; see
+// (*Buffer).View for the read-only contract.
+func (sb *StringBuffer) View() BufferInterface {
+	if sb == nil || sb.Buffer == nil {
+		return nil
+	}
+	return &StringBuffer{sb.Buffer.View()}
 }
 
 func (sb *StringBuffer) GoString() string {

--- a/pkg/types/buffer-ext.go
+++ b/pkg/types/buffer-ext.go
@@ -12,30 +12,39 @@ import (
 // It prevents unbounded allocations from untrusted input.
 const MaxPayloadSize = 128 * 1024 * 1024
 
-type BufferInterface interface {
-	io.ReadWriteSeeker
-	io.ReaderFrom
+// ReadableBuffer is the read-only subset of BufferInterface.
+// View() returns a ReadableBuffer so the compiler prevents callers from
+// accidentally calling write/mutate methods on a buffer whose underlying
+// bytes are shared with the original.
+type ReadableBuffer interface {
+	io.Reader
+	io.Seeker
 	io.WriterTo
 	io.ByteScanner
-	io.ByteWriter
 	io.RuneScanner
-	io.StringWriter
-	WriteRune(rune) (int, error)
 	Bytes() []byte
-	AvailableBuffer() []byte
 	fmt.Stringer
 	Peek(int) ([]byte, error)
-	fmt.GoStringer
 	Len() int
 	Size() int64
 	Cap() int
 	Available() int
-	Truncate(int)
-	Reset()
-	Grow(int)
 	Next(int) []byte
 	ReadBytes(byte) ([]byte, error)
 	ReadString(byte) (string, error)
+}
+
+type BufferInterface interface {
+	ReadableBuffer
+	io.Writer
+	io.ReaderFrom
+	io.ByteWriter
+	io.StringWriter
+	WriteRune(rune) (int, error)
+	AvailableBuffer() []byte
+	Truncate(int)
+	Reset()
+	Grow(int)
 	Clone() BufferInterface
 }
 
@@ -67,7 +76,7 @@ func (b *Buffer) Clone() *Buffer {
 // is in flight) as read-only with respect to the underlying bytes —
 // any write/grow/truncate on either side will race. Reads through
 // independent views are safe because each view has its own off.
-func (b *Buffer) View() *Buffer {
+func (b *Buffer) View() ReadableBuffer {
 	if b == nil {
 		return nil
 	}
@@ -124,11 +133,11 @@ func (b *BytesBuffer) Clone() BufferInterface {
 
 // View returns a BytesBuffer that shares b's underlying bytes; see
 // (*Buffer).View for the read-only contract.
-func (b *BytesBuffer) View() BufferInterface {
+func (b *BytesBuffer) View() ReadableBuffer {
 	if b == nil || b.Buffer == nil {
 		return nil
 	}
-	return &BytesBuffer{b.Buffer.View()}
+	return &BytesBuffer{b.Buffer.View().(*Buffer)}
 }
 
 func (b *BytesBuffer) GoString() string {
@@ -167,11 +176,11 @@ func (sb *StringBuffer) Clone() BufferInterface {
 
 // View returns a StringBuffer that shares sb's underlying bytes; see
 // (*Buffer).View for the read-only contract.
-func (sb *StringBuffer) View() BufferInterface {
+func (sb *StringBuffer) View() ReadableBuffer {
 	if sb == nil || sb.Buffer == nil {
 		return nil
 	}
-	return &StringBuffer{sb.Buffer.View()}
+	return &StringBuffer{sb.Buffer.View().(*Buffer)}
 }
 
 func (sb *StringBuffer) GoString() string {

--- a/servers/engine/socket.go
+++ b/servers/engine/socket.go
@@ -494,6 +494,7 @@ func (s *socket) sendPacket(
 		opts := &packet.Options{}
 		if options != nil {
 			opts.WsPreEncodedFrame = options.WsPreEncodedFrame
+			opts.PreparedFrame = options.PreparedFrame
 			if options.Compress != nil {
 				compress := *options.Compress
 				opts.Compress = &compress

--- a/servers/engine/socket.go
+++ b/servers/engine/socket.go
@@ -489,28 +489,16 @@ func (s *socket) sendPacket(
 	if readystate := s.ReadyState(); readystate != "closing" && readystate != "closed" {
 		socketLog.Debug(`sending packet "%s" (%p)`, packetType, data)
 
-		// Clone options to avoid data races when the same Options pointer
-		// is shared across multiple sockets during broadcast.
-		opts := &packet.Options{}
-		if options != nil {
-			opts.WsPreEncodedFrame = options.WsPreEncodedFrame
-			opts.PreparedFrame = options.PreparedFrame
-			if options.Compress != nil {
-				compress := *options.Compress
-				opts.Compress = &compress
-			}
-		}
-
-		if opts.Compress == nil || *opts.Compress {
-			opts.Compress = utils.Ptr(true)
-		} else {
-			opts.Compress = utils.Ptr(false)
-		}
-
+		// Pass options through without cloning. Options is read-only
+		// downstream (transports only inspect Compress / WsPreEncodedFrame /
+		// PreparedFrame), and the previous defensive clone-and-normalize
+		// dance was the largest per-recipient allocation in the broadcast
+		// hot path. Each transport handles a nil Compress as the documented
+		// default (compress = true) on its own.
 		packet := &packet.Packet{
 			Type:    packetType,
 			Data:    data,
-			Options: opts,
+			Options: options,
 		}
 
 		// exports packetCreate event

--- a/servers/engine/socket.go
+++ b/servers/engine/socket.go
@@ -489,12 +489,15 @@ func (s *socket) sendPacket(
 	if readystate := s.ReadyState(); readystate != "closing" && readystate != "closed" {
 		socketLog.Debug(`sending packet "%s" (%p)`, packetType, data)
 
-		// Pass options through without cloning. Options is read-only
-		// downstream (transports only inspect Compress / WsPreEncodedFrame /
-		// PreparedFrame), and the previous defensive clone-and-normalize
-		// dance was the largest per-recipient allocation in the broadcast
-		// hot path. Each transport handles a nil Compress as the documented
-		// default (compress = true) on its own.
+		// Pass options through without cloning — including nil.
+		// Nil-safety is enforced at each transport:
+		//   websocket/webtransport send(): `if packet.Options != nil` guards
+		//     every access to Compress, WsPreEncodedFrame, and PreparedFrame.
+		//   polling send(): `opt == nil || opt.Compress == nil || *opt.Compress`
+		//     short-circuits correctly when Options or Compress is nil.
+		// The previous defensive clone-and-normalize (which always produced a
+		// non-nil Options with a non-nil Compress) was the largest per-recipient
+		// allocation in the broadcast hot path and is no longer necessary.
 		packet := &packet.Packet{
 			Type:    packetType,
 			Data:    data,

--- a/servers/engine/transports/polling.go
+++ b/servers/engine/transports/polling.go
@@ -270,7 +270,7 @@ func (p *polling) send(packets []*packet.Packet) {
 
 	// Compress unless every packet explicitly opted out. A nil Options
 	// or nil Compress is treated as the documented default (true), which
-	// preserves behaviour after dropping the per-send Options clone in
+	// preserves behavior after dropping the per-send Options clone in
 	// engine.io's sendPacket.
 	compress := false
 	for _, packetData := range packets {

--- a/servers/engine/transports/polling.go
+++ b/servers/engine/transports/polling.go
@@ -268,9 +268,14 @@ func (p *polling) send(packets []*packet.Packet) {
 		p.shouldClose.Store(nil)
 	}
 
+	// Compress unless every packet explicitly opted out. A nil Options
+	// or nil Compress is treated as the documented default (true), which
+	// preserves behaviour after dropping the per-send Options clone in
+	// engine.io's sendPacket.
 	compress := false
 	for _, packetData := range packets {
-		if packetData.Options != nil && packetData.Options.Compress != nil && *packetData.Options.Compress {
+		opt := packetData.Options
+		if opt == nil || opt.Compress == nil || *opt.Compress {
 			compress = true
 			break
 		}

--- a/servers/engine/transports/websocket.go
+++ b/servers/engine/transports/websocket.go
@@ -152,12 +152,24 @@ func (w *websocket) send(packets []*packet.Packet) {
 				if _, ok := packet.Options.WsPreEncodedFrame.(*types.StringBuffer); ok {
 					mt = ws.TextMessage
 				}
-				pm, err := ws.NewPreparedMessage(mt, packet.Options.WsPreEncodedFrame.Bytes())
+				build := func() (any, error) {
+					return ws.NewPreparedMessage(mt, packet.Options.WsPreEncodedFrame.Bytes())
+				}
+				var (
+					v   any
+					err error
+				)
+				if cache := packet.Options.PreparedFrame; cache != nil {
+					v, err = cache.Do(WEBSOCKET, build)
+				} else {
+					v, err = build()
+				}
 				if err != nil {
 					wsLog.Debug(`Send Error "%s"`, err.Error())
 					w._error(err)
 					return
 				}
+				pm := v.(*ws.PreparedMessage)
 				if err := w.socket.WritePreparedMessage(pm); err != nil {
 					wsLog.Debug(`Send Error "%s"`, err.Error())
 					w._error(err)

--- a/servers/engine/transports/webtransport.go
+++ b/servers/engine/transports/webtransport.go
@@ -146,12 +146,24 @@ func (w *webTransport) send(packets []*packet.Packet) {
 				if _, ok := packet.Options.WsPreEncodedFrame.(*types.StringBuffer); ok {
 					mt = webtransport.TextMessage
 				}
-				pm, err := webtransport.NewPreparedMessage(mt, packet.Options.WsPreEncodedFrame.Bytes())
+				build := func() (any, error) {
+					return webtransport.NewPreparedMessage(mt, packet.Options.WsPreEncodedFrame.Bytes())
+				}
+				var (
+					v   any
+					err error
+				)
+				if cache := packet.Options.PreparedFrame; cache != nil {
+					v, err = cache.Do(WEBTRANSPORT, build)
+				} else {
+					v, err = build()
+				}
 				if err != nil {
 					wtLog.Debug(`Send Error "%s"`, err.Error())
 					w._error(err)
 					return
 				}
+				pm := v.(*webtransport.PreparedMessage)
 				if err := w.session.WritePreparedMessage(pm); err != nil {
 					wtLog.Debug(`Send Error "%s"`, err.Error())
 					w._error(err)

--- a/servers/socket/adapter.go
+++ b/servers/socket/adapter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	enginepacket "github.com/zishang520/socket.io/parsers/engine/v3/packet"
 	"github.com/zishang520/socket.io/parsers/socket/v3/parser"
 	"github.com/zishang520/socket.io/v3/pkg/types"
 	"github.com/zishang520/socket.io/v3/pkg/utils"
@@ -207,6 +208,12 @@ func (a *adapter) _encode(packet *parser.Packet, packetOpts *WriteOptions) []typ
 			_, _ = data.Write(p.Bytes())
 			// see https://github.com/websockets/ws/issues/617#issuecomment-283002469
 			packetOpts.WsPreEncodedFrame = data
+			// One cache per broadcast: each recipient transport builds
+			// its prepared frame at most once and reuses it for the
+			// rest of the recipients. Safe for unicast too: a single
+			// recipient just fills the cache without paying any extra
+			// cost.
+			packetOpts.PreparedFrame = &enginepacket.PreparedFrame{}
 		}
 	}
 

--- a/servers/socket/client.go
+++ b/servers/socket/client.go
@@ -164,6 +164,14 @@ func (c *Client) _packet(packet *parser.Packet, opts *WriteOptions) {
 	c.WriteToEngine(c.encoder.Encode(packet), opts)
 }
 
+// bufferViewer is implemented by buffers that can produce a cheap,
+// shared-bytes view of themselves with independent read state. The
+// adapter's broadcast path uses it to avoid a per-recipient byte-copy
+// of the encoded payload.
+type bufferViewer interface {
+	View() types.BufferInterface
+}
+
 // WriteToEngine writes encoded packets to the Engine.IO transport.
 func (c *Client) WriteToEngine(encodedPackets []types.BufferInterface, opts *WriteOptions) {
 	c.mu.Lock()
@@ -174,8 +182,21 @@ func (c *Client) WriteToEngine(encodedPackets []types.BufferInterface, opts *Wri
 		return
 	}
 
+	// Broadcast fast path: when WsPreEncodedFrame is set the adapter has
+	// already pre-encoded a payload that is shared across every recipient,
+	// so the underlying bytes are read-only. Hand each recipient a cheap
+	// View instead of a deep Clone — the bytes stay shared but the read
+	// state stays independent. Falls back to Clone for buffers that don't
+	// implement the optional View method, and for unicast emits.
+	broadcast := opts.WsPreEncodedFrame != nil
 	for _, encodedPacket := range encodedPackets {
-		c.conn.Write(encodedPacket.Clone(), &opts.Options, nil)
+		var data types.BufferInterface
+		if v, ok := encodedPacket.(bufferViewer); ok && broadcast {
+			data = v.View()
+		} else {
+			data = encodedPacket.Clone()
+		}
+		c.conn.Write(data, &opts.Options, nil)
 	}
 }
 

--- a/servers/socket/client.go
+++ b/servers/socket/client.go
@@ -1,6 +1,7 @@
 package socket
 
 import (
+	"io"
 	"net/url"
 	"sync"
 	"sync/atomic"
@@ -169,7 +170,7 @@ func (c *Client) _packet(packet *parser.Packet, opts *WriteOptions) {
 // adapter's broadcast path uses it to avoid a per-recipient byte-copy
 // of the encoded payload.
 type bufferViewer interface {
-	View() types.BufferInterface
+	View() types.ReadableBuffer
 }
 
 // WriteToEngine writes encoded packets to the Engine.IO transport.
@@ -188,9 +189,14 @@ func (c *Client) WriteToEngine(encodedPackets []types.BufferInterface, opts *Wri
 	// View instead of a deep Clone — the bytes stay shared but the read
 	// state stays independent. Falls back to Clone for buffers that don't
 	// implement the optional View method, and for unicast emits.
+	//
+	// View() returns ReadableBuffer (not BufferInterface) so the compiler
+	// prevents write/mutate calls on the shared bytes. Both ReadableBuffer
+	// and BufferInterface satisfy io.Reader, which is all engine.Socket.Write
+	// requires.
 	broadcast := opts.WsPreEncodedFrame != nil
 	for _, encodedPacket := range encodedPackets {
-		var data types.BufferInterface
+		var data io.Reader
 		if v, ok := encodedPacket.(bufferViewer); ok && broadcast {
 			data = v.View()
 		} else {


### PR DESCRIPTION
…cipient

Today every recipient of a broadcast pays the cost of ws.NewPreparedMessage / webtransport.NewPreparedMessage even though the frame bytes are identical for the entire broadcast. With N matching sockets that is N redundant frame allocations and an N-fold loss of the per-frame cache that gorilla/websocket keeps inside PreparedMessage.

Introduce an opaque, transport-keyed, build-once cache (packet.PreparedFrame). The default adapter allocates one cache per broadcast in _encode (next to where it sets WsPreEncodedFrame) and threads it through Options. The websocket and webtransport transports build their PreparedMessage on first send and reuse the cached value for every remaining recipient.

Backward compatible: when PreparedFrame is nil (unicast emits, custom adapters that don't set it, anything outside the broadcast path) the behavior is identical. The cache is allocated only inside the existing single-string fast path, so binary and polling paths are unaffected.