### PR TITLE
fix(transports): close write queue on ungraceful disconnect

### DIFF
--- a/servers/engine/transports/polling.go
+++ b/servers/engine/transports/polling.go
@@ -247,6 +247,10 @@ func (p *polling) OnClose() {
 			},
 		})
 	}
+	// Always tear down the write queue, even on ungraceful disconnects
+	// where DoClose never runs. See the matching override on websocket
+	// for the full rationale.
+	p.writeQueue.TryClose()
 	p.Transport.OnClose()
 }
 

--- a/servers/engine/transports/websocket.go
+++ b/servers/engine/transports/websocket.go
@@ -207,6 +207,19 @@ func (w *websocket) write(data types.BufferInterface, compress bool) {
 	}
 }
 
+// OnClose tears down the write queue regardless of how the transport
+// reaches the "closed" state. The base Transport.Close() path runs
+// DoClose (which closes the queue), but any close that originates as
+// an error / unexpected peer drop goes straight through OnClose with
+// the state already flipped to "closed" — at which point a follow-up
+// Transport.Close() returns early and DoClose never fires. Without
+// this override the per-socket queue.loop goroutine waits on its
+// sync.Cond forever, leaking once per ungraceful disconnect.
+func (w *websocket) OnClose() {
+	w.writeQueue.TryClose()
+	w.Transport.OnClose()
+}
+
 // Closes the transport.
 func (w *websocket) DoClose(fn types.Callable) {
 	wsLog.Debug(`closing`)

--- a/servers/engine/transports/webtransport.go
+++ b/servers/engine/transports/webtransport.go
@@ -202,6 +202,15 @@ func (w *webTransport) write(data types.BufferInterface, _ bool) {
 	}
 }
 
+// OnClose tears down the write queue regardless of how the transport
+// reaches the "closed" state. See the matching override on websocket
+// for why the base path leaks the queue.loop goroutine on ungraceful
+// disconnects.
+func (w *webTransport) OnClose() {
+	w.writeQueue.TryClose()
+	w.Transport.OnClose()
+}
+
 // Closes the transport.
 func (w *webTransport) DoClose(fn types.Callable) {
 	wtLog.Debug(`closing WebTransport session`)


### PR DESCRIPTION
Each engine.io transport (websocket / webtransport / polling) owns a queue.Queue whose loop goroutine blocks on a sync.Cond until the queue is shut down via writeQueue.TryClose. The base Transport.Close path runs that close (via DoClose), but a transport that hits an I/O error or peer drop reaches OnClose with the state already flipped to "closed" — and any follow-up Transport.Close returns early without ever calling DoClose. The queue.loop goroutine then waits on its sync.Cond forever, leaking once per ungraceful disconnect.

Override OnClose on each transport so writeQueue.TryClose runs on both close paths. TryClose is idempotent (it only sets shuttingDown and broadcasts), so the explicit-Close path that already calls it through DoClose stays correct.

Observed before the fix: a 9 h run with ~240 connected clients had 1850 goroutines blocked in queue.(*Queue).get / sync.Cond.Wait — roughly one per disconnect — driving the heap above GOMEMLIMIT and keeping the GC mark workers at 86% CPU.