### PR TITLE
fix: Map.Len() counter drift and orphaned adapter rooms on concurrent Join+cleanup

### DIFF
--- a/pkg/types/map.go
+++ b/pkg/types/map.go
@@ -238,6 +238,9 @@ func (m *Map[TKey, TValue]) LoadOrStore(key TKey, value TValue) (actual TValue, 
 		var stored bool
 		actual, loaded, stored = e.tryLoadOrStore(value)
 		if stored {
+			if !loaded {
+				m.length.Add(1)
+			}
 			return actual, loaded
 		}
 	}
@@ -371,6 +374,7 @@ func (m *Map[TKey, TValue]) Swap(key TKey, value TValue) (previous TValue, loade
 	if e, ok := read.m[key]; ok {
 		if v, ok := e.trySwap(&value); ok {
 			if v == nil {
+				m.length.Add(1)
 				return previous, false
 			}
 			return *v, true

--- a/servers/socket/socket.go
+++ b/servers/socket/socket.go
@@ -133,6 +133,11 @@ type (
 		_anyOutgoingListeners *types.Slice[types.EventListener]
 
 		canJoin atomic.Bool
+		// joinMu serializes Join (AddAll) against _cleanup (DelAll).
+		// Join holds a read lock for the duration of adapter.AddAll so that
+		// _cleanup's write lock waits for any in-flight AddAll to finish before
+		// leaveAll/DelAll runs — preventing orphaned rooms[room] entries.
+		joinMu sync.RWMutex
 
 		taskQueue *queue.Queue
 	}
@@ -429,10 +434,11 @@ func (s *Socket) packet(packet *parser.Packet, opts *BroadcastFlags) {
 
 // Join adds the socket to one or more rooms.
 func (s *Socket) Join(rooms ...Room) {
+	s.joinMu.RLock()
+	defer s.joinMu.RUnlock()
 	if !s.canJoin.Load() {
 		return
 	}
-
 	socketLog.Debug("join room %s", rooms)
 	s.adapter.AddAll(s.id, types.NewSet(rooms...))
 }
@@ -593,9 +599,16 @@ func (s *Socket) _onclose(args ...any) {
 
 // Makes the socket leave all the rooms it was part of and prevents it from joining any other room
 func (s *Socket) _cleanup() {
+	// Acquire the write lock to wait for any in-flight Join/AddAll to complete,
+	// then set canJoin=false so no new Joins can start after we release.
+	// leaveAll/DelAll then runs without risk of a concurrent AddAll adding rooms
+	// back into adapter.rooms after they've been removed — which would orphan them.
+	s.joinMu.Lock()
+	s.canJoin.Store(false)
+	s.joinMu.Unlock()
+
 	s.leaveAll()
 	s.nsp.Remove(s)
-	s.canJoin.Store(false)
 	// Clear pending ack callbacks to prevent memory leaks
 	s.acks.Clear()
 	s.taskQueue.TryClose()


### PR DESCRIPTION
## What

Two bugs that cause persistent adapter state corruption and metric drift in production,
identified through Prometheus metrics and pprof profiling of a GPS fleet tracking service
running ~11 million socket.io broadcasts per 10 hours across 345 concurrent clients.

---

### Fix 1 — `pkg/types/map.go`: `Map.Len()` counter drift in `LoadOrStore` and `Swap` fast paths

**Root cause**

`types.Map` maintains an `atomic.Int64 length` counter that `Len()` reads.
Two fast paths fail to increment it when a nil entry (deleted-but-not-expunged key) is reused:

**`LoadOrStore` fast path** (`tryLoadOrStore`): when `stored=true, loaded=false` (nil entry reused),
the function returned before `m.length.Add(1)`. `LoadAndDelete` always decremented correctly.
Result: every reconnect cycle for an existing room name decremented without a matching increment.

**`Swap` fast path**: `trySwap` succeeds on a nil entry (`v == nil`) and returned early before
the slow-path `length.Add(1)`.

**Observed in production**: after the corresponding `joinMu` fix (below) made room counts accurate,
`adapter.Rooms().Len()` for `/alarms` showed **−2 656** at peak (128 sids, ~150 rooms/client,
thousands of reconnections). `/command` rooms showed exactly half of `/frames` rooms — wrong by a
factor of two, matching the two affected code paths.

**Fix**: call `m.length.Add(1)` in both fast paths when `!loaded`, matching the invariant of the slow path.

```go
// LoadOrStore fast path
actual, loaded, stored = e.tryLoadOrStore(value)
if stored {
    if !loaded {
        m.length.Add(1)   // was missing
    }
    return actual, loaded
}

// Swap fast path
if v == nil {
    m.length.Add(1)       // was missing
    return previous, false
}
```

---

### Fix 2 — `servers/socket/socket.go`: orphaned adapter rooms on concurrent `Join` + `_cleanup`

**Root cause**

`Join` → `adapter.AddAll` and `_cleanup` → `leaveAll` → `adapter.DelAll` run on different goroutines
with no mutual exclusion:

1. `taskQueue` goroutine begins `AddAll(id, rooms)`: loads `sids[id]` into a local `_rooms`, iterates rooms to add.
2. Engine.io close goroutine concurrently calls `_cleanup` → `leaveAll` → `DelAll(id)`:
   - reads `sids[id]` (partial — only rooms added so far)
   - removes `id` from each `rooms[room]` set
   - **deletes `sids[id]`**
3. `taskQueue` goroutine continues with the stale `_rooms` reference: inserts remaining rooms into `adapter.rooms[x]` for a socket ID that no longer exists in `sids`.

Those entries in `adapter.rooms` are permanently orphaned — `DelAll` will never visit them again.

**Observed in production** (after fix 1 made counters accurate): rooms count grew by +104 while
sids dropped by 8 in a 13-minute window — a rate of **~480 orphaned rooms/hour**.

**Fix**

Add `joinMu sync.RWMutex` to `Socket`:

- `Join` holds a **read lock** for the entire duration of `adapter.AddAll` — the check+add is now atomic from `_cleanup`'s perspective.
- `_cleanup` acquires the **write lock** (waiting for any in-flight `AddAll` to finish), sets `canJoin = false`, releases the lock, then calls `leaveAll`/`DelAll`.

`DelAll` now always sees the complete room set for this socket. No rooms escape cleanup.

```go
func (s *Socket) Join(rooms ...Room) {
    s.joinMu.RLock()
    defer s.joinMu.RUnlock()
    if !s.canJoin.Load() { return }
    s.adapter.AddAll(s.id, types.NewSet(rooms...))
}

func (s *Socket) _cleanup() {
    s.joinMu.Lock()
    s.canJoin.Store(false)
    s.joinMu.Unlock()
    // All in-flight AddAll calls have now completed.
    s.leaveAll()
    s.nsp.Remove(s)
    s.acks.Clear()
    s.taskQueue.TryClose()
}
```

---

## Production verification

Metrics before and after deploying both fixes to production (10 h soak, same workload):

| Metric | Before | After |
|---|---|---|
| `adapter_rooms_total{ns="/alarms"}` | −2 656 (drifted) | 230 (128 sids × ~1.8 rooms) ✓ |
| `adapter_rooms_total{ns="/frames"}` | growing ~480/h vs stable sids | proportional to sids ✓ |
| `adapter_rooms_total{ns="/command"}` | ½ of `/frames` (wrong) | equal to `/frames` ✓ |

No new unit tests — both races require concurrent scheduling to reproduce reliably.
The production goroutine profiles and Prometheus time-series are the evidence.