### PR TITLE
fix(utils): fix goroutine leak in Timer.Stop() on Go 1.23+

### DIFF
--- a/pkg/utils/timer.go
+++ b/pkg/utils/timer.go
@@ -70,7 +70,7 @@ func (t *Timer) Stop() {
 	// In Go 1.23+, time.Timer.Stop() drains the C channel when returning false
 	// (timer had already expired). Without the unconditional signal below, the
 	// goroutine inside timer.fn would be permanently blocked: it can no longer
-	// receive from the now-empty C, and stopCh was never signalled.
+	// receive from the now-empty C, and stopCh was never signaled.
 	// The buffered channel (cap 1) ensures the signal is queued even if the
 	// goroutine hasn't reached its select yet.
 	t.timer.Stop()

--- a/pkg/utils/timer.go
+++ b/pkg/utils/timer.go
@@ -36,7 +36,7 @@ func SetTimeout(fn func(), sleep time.Duration) *Timer {
 	timer := &Timer{
 		timer:  time.NewTimer(sleep),
 		sleep:  sleep,
-		stopCh: make(chan struct{}),
+		stopCh: make(chan struct{}, 1),
 	}
 	timer.fn = func() {
 		defer func() {
@@ -66,13 +66,17 @@ func ClearTimeout(timer *Timer) {
 }
 
 func (t *Timer) Stop() {
-	if t.timer.Stop() {
-		// Use non-blocking send to avoid goroutine leak if no reader
-		select {
-		case t.stopCh <- struct{}{}:
-		default:
-			// Channel is full or no reader, timer already stopped
-		}
+	// Always stop the underlying timer regardless of whether it already fired.
+	// In Go 1.23+, time.Timer.Stop() drains the C channel when returning false
+	// (timer had already expired). Without the unconditional signal below, the
+	// goroutine inside timer.fn would be permanently blocked: it can no longer
+	// receive from the now-empty C, and stopCh was never signalled.
+	// The buffered channel (cap 1) ensures the signal is queued even if the
+	// goroutine hasn't reached its select yet.
+	t.timer.Stop()
+	select {
+	case t.stopCh <- struct{}{}:
+	default:
 	}
 }
 
@@ -80,7 +84,7 @@ func SetInterval(fn func(), sleep time.Duration) *Timer {
 	timer := &Timer{
 		timer:  time.NewTimer(sleep),
 		sleep:  sleep,
-		stopCh: make(chan struct{}),
+		stopCh: make(chan struct{}, 1),
 	}
 	timer.fn = func() {
 		defer func() {


### PR DESCRIPTION
## Problem

`Timer.Stop()` has two independent bugs that combine to permanently leak the goroutine started inside `SetTimeout`:

**Bug 1 — conditional signal.**
`Stop()` only signalled `stopCh` when `t.timer.Stop()` returned `true`.
Go 1.23 changed `time.Timer.Stop()` to drain the `C` channel itself when the timer has already fired (previously the caller had to drain). So if the timer fires just before `Stop()` is called:

```
goroutine (in SetTimeout):       caller:
select {
  case <-timer.C:                             // fires, goroutine about to read
    fn()                                      // starts executing fn
  case <-stopCh:
}
                                 t.timer.Stop()   // returns false (already fired);
                                                  // Go 1.23 drains C
                                 // stopCh never signalled → goroutine blocks forever
```

After `fn()` returns the goroutine enters the `defer` block, tries to drain `stopCh`, and falls through to `default`. The goroutine is then permanently blocked because `C` is empty (drained by `Stop()`) and `stopCh` was never written.

**Bug 2 — unbuffered channel.**
`stopCh` was `make(chan struct{})` (unbuffered). The non-blocking send `case t.stopCh <- struct{}{}: default:` silently drops the signal if the goroutine has not yet reached its `select` statement (e.g., scheduler pressure at high CPU). Result: same permanent block.

## Fix

```diff
-stopCh: make(chan struct{}),
+stopCh: make(chan struct{}, 1),   // buffered: queues the signal until goroutine is ready

 func (t *Timer) Stop() {
-    if t.timer.Stop() {
-        select {
-        case t.stopCh <- struct{}{}:
-        default:
-        }
-    }
+    t.timer.Stop()               // always stop; Go 1.23+ drains C if already fired
+    select {
+    case t.stopCh <- struct{}{}:  // always signal so goroutine exits
+    default:
+    }
 }
```

Same change applied to `SetInterval` (uses the same `stopCh`).

## Observed Impact

Production profiling of a GPS pub/sub relay (364 WebSocket clients, Go 1.26.2, GOMAXPROCS=2):

| Metric | Before fix | After fix (6 h snapshot) |
|--------|-----------|--------------------------|
| Leaked `connectTimeout` goroutines | ~177 / h (1 770 / 10 h) | 0 |
| Leaked queue goroutines per leaked timer | 3 (one per socket.io namespace) | — |
| Total leaked queue goroutines | ~531 / h (5 310 / 10 h) | 0 |

Goroutine profile after 6 h with the fix applied — all goroutine counts balance:

```
engine_io_queue_created_total  60 422
engine_io_queue_closed_total   58 527
engine_io_queue_goroutines      1 895  ← created − closed = gauge ✓

engine_io_transport_created{websocket}  19 307
engine_io_transport_closed{websocket}   18 800
websocket reader goroutines                507  ← delta = goroutines ✓
SetTimeout goroutines                      507  ← 1:1 with active transports ✓
```

Before the fix, after 10 h the `SetTimeout` goroutines exceeded the active-transport count by ~1 770, and each blocked goroutine held its write-queue loop goroutine (via `sync.Cond.Wait`), preventing `engine_io_queue_goroutines` from ever matching `created − closed`.

## Why only `pkg/utils/timer.go`

`connectTimeout` timers inside engine.io call `SetTimeout` / `ClearTimeout` from this package. Every client connection creates one; `ClearTimeout` calls `Stop()` when the connection handshake completes. Any handshake that races with timer expiry triggers bug 1, and any `Stop()` arriving under CPU pressure triggers bug 2.