### PR TITLE
fix(engine): avoid duplicate WriteHeader on failed websocket upgrade

### DIFF
--- a/servers/engine/server.go
+++ b/servers/engine/server.go
@@ -122,8 +122,8 @@ func (s *server) HandleUpgrade(ctx *types.HttpContext) {
 			ReadBufferSize:    DefaultWSReadBufferSize,
 			WriteBufferSize:   DefaultWSWriteBufferSize,
 			EnableCompression: s.Opts().PerMessageDeflate() != nil,
-			Error: func(w http.ResponseWriter, r *http.Request, status int, reason error) {
-				http.Error(w, reason.Error(), status)
+			Error: func(_ http.ResponseWriter, _ *http.Request, _ int, reason error) {
+				// response is written by emitAbortRequest below
 				wsc.Emit("error", reason)
 			},
 		}

--- a/servers/engine/server_upgrade_test.go
+++ b/servers/engine/server_upgrade_test.go
@@ -1,0 +1,40 @@
+package engine
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// countingResponseWriter counts calls to WriteHeader.
+type countingResponseWriter struct {
+	header       http.Header
+	writeHeaders int
+}
+
+func (w *countingResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *countingResponseWriter) WriteHeader(int) { w.writeHeaders++ }
+
+func (w *countingResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+
+func TestFailedUpgradeWritesHeaderOnce(t *testing.T) {
+	s := NewServer(nil)
+
+	// missing Sec-WebSocket-Version so the gorilla handshake fails
+	req := httptest.NewRequest(http.MethodGet, "/engine.io/?EIO=4&transport=websocket", nil)
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Upgrade", "websocket")
+
+	w := &countingResponseWriter{}
+	s.ServeHTTP(w, req)
+
+	if w.writeHeaders != 1 {
+		t.Fatalf("WriteHeader called %d times on a failed upgrade, want 1", w.writeHeaders)
+	}
+}


### PR DESCRIPTION
Fixes #171.

On a failed WebSocket upgrade the response header is written twice on the same `ResponseWriter`, so net/http logs `http: superfluous response.WriteHeader call ... performWrite (http-context.go:214)` once per failed upgrade. See #171 for the full trace.

The gorilla `Upgrader.Error` callback in `HandleUpgrade` calls `http.Error(w, …)` (write #1, straight to the underlying writer, bypassing `HttpContext`'s write-once guard); the following `emitAbortRequest` → `abortRequest` → `ctx.Write` → `performWrite` is write #2.

### Change

Removed the `http.Error` from the `Error` callback. `emitAbortRequest` (called right after `ws.Upgrade` fails) is the canonical responder — it writes the engine.io JSON error and emits `connection_error` — so a failed upgrade now writes the header exactly once, and clients get the proper engine.io error payload instead of gorilla's plain-text body. The WebTransport path (`OnWebTransportSession`) has no such callback and is unaffected.

### Test

Added `TestFailedUpgradeWritesHeaderOnce`: it drives a failed upgrade through `ServeHTTP` with a `ResponseWriter` that counts `WriteHeader` calls and asserts it is called exactly once. Fails before the change (2 calls), passes after. `go test -race ./...` in `servers/engine` is green.
