### PR TITLE
fix(queue): release closed queue task storage

### DIFF
--- a/pkg/queue/queue.go
+++ b/pkg/queue/queue.go
@@ -3,7 +3,6 @@
 package queue
 
 import (
-	"runtime"
 	"runtime/debug"
 	"sync"
 
@@ -32,7 +31,6 @@ func New() *Queue {
 	q.cond = sync.NewCond(&q.mu)
 
 	go q.loop()
-	runtime.SetFinalizer(q, func(q *Queue) { q.TryClose() })
 	return q
 }
 
@@ -63,7 +61,12 @@ func (q *Queue) Size() int {
 
 // loop is the main consumer goroutine.
 func (q *Queue) loop() {
-	defer close(q.done)
+	defer func() {
+		q.mu.Lock()
+		q.tasks = nil
+		q.mu.Unlock()
+		close(q.done)
+	}()
 
 	for {
 		task, ok := q.get()

--- a/pkg/queue/queue_extended_test.go
+++ b/pkg/queue/queue_extended_test.go
@@ -90,6 +90,41 @@ func TestQueue_TryCloseAndEnqueue(t *testing.T) {
 	}
 }
 
+func TestQueue_ReleasesTasksOnClose(t *testing.T) {
+	q := New()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	q.Enqueue(func() {
+		close(started)
+		<-release
+	})
+	<-started
+
+	for range 2048 {
+		q.Enqueue(func() {})
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		q.Close()
+		close(closed)
+	}()
+
+	close(release)
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Queue did not close")
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if got := cap(q.tasks); got != 0 {
+		t.Fatalf("Queue retained task backing array after close: cap=%d", got)
+	}
+}
+
 func TestQueue_SizeEmpty(t *testing.T) {
 	q := New()
 	defer q.Close()


### PR DESCRIPTION
## Problem

`pkg/queue/queue.go` installs a finalizer on every `Queue` while `sync.Cond` retains a pointer to the queue mutex. After a queue is closed, this creates an unreachable finalizer-bearing cycle:

```
Queue -> sync.Cond -> Locker(&Queue.mu) -> Queue
```

The queue worker exits, but the queue and its preallocated `tasks` backing array can remain retained. Socket.IO creates one task queue and Engine.IO creates one write queue per full connection, so this accumulates over connection churn.

## Evidence

In production heap profiles, historical queue storage accounted for approximately 435-456 MiB while only the queues belonging to active WebSocket connections had running queue goroutines.

An isolated test created 5,000 queues, called `TryClose`, waited for workers to exit, and forced GC:

- Finalizer retained: approximately 48.8 MB per batch, with zero goroutine growth.
- Finalizer cleared in the control batch: approximately 40 KB.

This demonstrates that the retention does not require an application-level map leak.

## Change

- Remove the queue finalizer. Queue owners already explicitly call `TryClose` or `Close`.
- Release `q.tasks` when the worker exits.
- Preserve the existing drain behavior: `TryClose` does not discard pending tasks.
- Add a regression test that verifies the task backing array is released after `Close`.

## Validation

```text
go test ./...
go test -race ./pkg/queue
```

Both pass.

Fixes #184
