### PR TITLE
fix(engine): close the hijacked websocket connection on ungraceful disconnect

### DIFF
--- a/pkg/types/events.go
+++ b/pkg/types/events.go
@@ -180,7 +180,11 @@ type oneTimeListener struct {
 
 func (l *oneTimeListener) execute(vals ...any) {
 	l.fired.Do(func() {
-		defer l.emitter.RemoveListener(l.evt, l.fn)
+		// Remove the listener before invoking it, matching Node.js
+		// EventEmitter's "once": a listener that emits its own event from
+		// inside its body must not re-enter the (already firing) one-time
+		// listener, which would deadlock on the sync.Once below.
+		l.emitter.RemoveListener(l.evt, l.fn)
 		l.fn(vals...)
 	})
 }

--- a/pkg/types/events_test.go
+++ b/pkg/types/events_test.go
@@ -353,3 +353,31 @@ func TestConcurrentRemoveAll(t *testing.T) {
 		t.Fatalf("Expected 0 listeners after removal, got %d", count)
 	}
 }
+
+// TestOnceListenerReentrantEmitDoesNotDeadlock reproduces the deadlock where a
+// listener registered with Once re-emits the same event from within its own
+// body: the one-time listener must already be removed before invocation (as in
+// Node.js EventEmitter), otherwise the nested Emit re-enters the listener's
+// sync.Once and deadlocks.
+func TestOnceListenerReentrantEmitDoesNotDeadlock(t *testing.T) {
+	emitter := NewEventEmitter()
+
+	done := make(chan struct{})
+	if err := emitter.Once("evt", func(...any) {
+		// Re-entrant emit from inside the once listener; must be a no-op.
+		// Signal only after it returns, so a deadlock fails the test.
+		emitter.Emit("evt")
+		close(done)
+	}); err != nil {
+		t.Fatalf("failed to register Once listener: %v", err)
+	}
+
+	// Run in a goroutine so a deadlock fails the test instead of hanging it.
+	go emitter.Emit("evt")
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("re-entrant Emit from within a Once listener deadlocked")
+	}
+}

--- a/servers/engine/transports/websocket.go
+++ b/servers/engine/transports/websocket.go
@@ -231,9 +231,15 @@ func (w *websocket) write(data types.BufferInterface, compress bool) {
 // Transport.Close() returns early and DoClose never fires. Without
 // this override the per-socket queue.loop goroutine waits on its
 // sync.Cond forever, leaking once per ungraceful disconnect.
+//
+// The hijacked websocket connection is closed here as well, so an
+// ungraceful disconnect (where DoClose never runs) still releases the
+// underlying connection instead of leaking it. socket.Close is
+// idempotent, so closing again on the DoClose path is harmless.
 func (w *websocket) OnClose() {
 	w.writeQueue.TryClose()
 	w.Transport.OnClose()
+	_ = w.socket.Close()
 }
 
 // Closes the transport.

--- a/servers/engine/transports/websocket_test.go
+++ b/servers/engine/transports/websocket_test.go
@@ -1,0 +1,113 @@
+package transports
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	ws "github.com/gorilla/websocket"
+	"github.com/zishang520/socket.io/v3/pkg/types"
+)
+
+// recordingConn records Close calls on the underlying connection so a test can
+// assert that the transport actually closed the hijacked HTTP connection.
+type recordingConn struct {
+	net.Conn
+	closed atomic.Bool
+}
+
+func (c *recordingConn) Close() error {
+	c.closed.Store(true)
+
+	return c.Conn.Close()
+}
+
+// hijackResponseWriter is an http.ResponseWriter that hands the underlying
+// connection to gorilla's Upgrader via Hijack, mirroring what net/http does for
+// a real websocket upgrade.
+type hijackResponseWriter struct {
+	conn net.Conn
+}
+
+func (w *hijackResponseWriter) Header() http.Header         { return make(http.Header) }
+func (w *hijackResponseWriter) WriteHeader(int)             {}
+func (w *hijackResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+
+func (w *hijackResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return w.conn, bufio.NewReadWriter(bufio.NewReader(w.conn), bufio.NewWriter(w.conn)), nil
+}
+
+// TestWebsocketTransportClosesConnectionOnPeerClose reproduces the
+// connection-cap slot leak (DELIVERY-725): on a client-initiated websocket
+// close the transport marks itself "closed" without closing the hijacked HTTP
+// connection. The hijacked connection must be closed once the transport
+// reaches the closed state, regardless of the close path.
+func TestWebsocketTransportClosesConnectionOnPeerClose(t *testing.T) {
+	clientRaw, serverRaw := net.Pipe()
+	server := &recordingConn{Conn: serverRaw}
+	defer clientRaw.Close()
+	defer server.Close()
+
+	// Client handshake runs over the pipe: gorilla's Dialer writes the upgrade
+	// request to clientRaw; the server side reads it and upgrades. A custom
+	// dialer returns the pipe end so no real TCP connection is opened.
+	type clientResult struct {
+		conn *ws.Conn
+		err  error
+	}
+	resultCh := make(chan clientResult, 1)
+	go func() {
+		dialer := &ws.Dialer{
+			NetDial: func(string, string) (net.Conn, error) {
+				return clientRaw, nil
+			},
+		}
+		conn, resp, err := dialer.Dial("ws://localhost/socket.io/?EIO=4&transport=websocket", nil)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		resultCh <- clientResult{conn: conn, err: err}
+	}()
+
+	// Server side: read the client's upgrade request from the pipe and upgrade.
+	req, err := http.ReadRequest(bufio.NewReader(server))
+	if err != nil {
+		t.Fatalf("read upgrade request: %v", err)
+	}
+	upgrader := ws.Upgrader{}
+	serverWS, err := upgrader.Upgrade(&hijackResponseWriter{conn: server}, req, nil)
+	if err != nil {
+		t.Fatalf("upgrade failed: %v", err)
+	}
+	res := <-resultCh
+	if res.err != nil {
+		t.Fatalf("client dial failed: %v", res.err)
+	}
+	clientWS := res.conn
+	defer clientWS.Close()
+
+	// Build the transport around the server-side websocket, as the engine
+	// server does after a successful upgrade.
+	wsc := &types.WebSocketConn{EventEmitter: types.NewEventEmitter(), Conn: serverWS}
+	ctx := types.NewHttpContext(&hijackResponseWriter{conn: server}, req)
+	ctx.Websocket = wsc
+	NewWebSocket(ctx)
+
+	// The peer closes the websocket connection.
+	if err := clientWS.WriteMessage(ws.CloseMessage, ws.FormatCloseMessage(ws.CloseNormalClosure, "")); err != nil {
+		t.Fatalf("write close frame: %v", err)
+	}
+
+	// The hijacked connection must be closed; otherwise the slot it holds
+	// leaks (a poll is used so a missing close fails the test cleanly).
+	deadline := time.Now().Add(2 * time.Second)
+	for !server.closed.Load() {
+		if time.Now().After(deadline) {
+			t.Fatal("websocket transport did not close the hijacked connection on peer close")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/servers/engine/transports/websocket_test.go
+++ b/servers/engine/transports/websocket_test.go
@@ -2,6 +2,7 @@ package transports
 
 import (
 	"bufio"
+	"context"
 	"net"
 	"net/http"
 	"sync/atomic"
@@ -73,10 +74,16 @@ func TestWebsocketTransportClosesConnectionOnPeerClose(t *testing.T) {
 	}()
 
 	// Server side: read the client's upgrade request from the pipe and upgrade.
+	// The client sends nothing beyond the request until the handshake completes,
+	// so no bytes are stranded in the ReadRequest buffer when gorilla creates
+	// its own reader after the upgrade.
+	reqCtx, cancelReq := context.WithCancel(context.Background())
+	defer cancelReq()
 	req, err := http.ReadRequest(bufio.NewReader(server))
 	if err != nil {
 		t.Fatalf("read upgrade request: %v", err)
 	}
+	req = req.WithContext(reqCtx)
 	upgrader := ws.Upgrader{}
 	serverWS, err := upgrader.Upgrade(&hijackResponseWriter{conn: server}, req, nil)
 	if err != nil {


### PR DESCRIPTION
## Problem

On a client/error-initiated websocket close, the websocket transport reaches `OnClose` with the state already flipped to `closed` (this is exactly what `1d5eef8` documented for the queue fix). The follow-up `Transport.Close()` then returns early and `DoClose` — the **only** path that closes the hijacked connection — never fires. The hijacked HTTP connection (and any per-connection resource the server holds, e.g. a connection cap slot or an fd) leaks until process exit.

A second, independent bug makes the obvious fix unsafe: `oneTimeListener.execute` removes the one-time listener only *after* invoking it, so a listener that closes the socket (which emits `close`) from inside its own body re-enters the listener and deadlocks on its `sync.Once`.

## Fix (two minimal changes)

1. **`pkg/types/events.go` — remove a `once` listener before invoking it** (matches Node.js EventEmitter semantics). A listener that re-emits its own event is now a no-op instead of a deadlock. This is what makes closing the connection from within the close cascade safe.
2. **`servers/engine/transports/websocket.go` — close the hijacked connection in `OnClose`.** `socket.Close()` is idempotent, so the server-initiated `DoClose` path is unaffected; the ungraceful path (where `DoClose` never runs) now releases the underlying connection.

Either path (read-loop error/close frame, or server-initiated `Transport.Close()`) now deterministically closes the connection — the close race is resolved instead of double-closing.

## Tests

- `pkg/types/events_test.go`: a `Once` listener that re-emits its own event completes (repro of the deadlock; fails before fix 1).
- `servers/engine/transports/websocket_test.go`: a real websocket pair over a pipe; after the peer sends a close frame the hijacked connection must be closed (repro of the leak; fails before fix 2).

## Validation

- `go test ./...`, `go test -race`, `go vet`, golangci-lint — all modules green (the `adapters/redis` suite needs a local Redis and is unchanged by this PR).
- End-to-end: in a consumer (avride/delivery) that counts every hijacked connection against a connection-cap semaphore, the cap-slot leak regression tests pass with **only this upstream fix** and the consumer-side workaround disabled.